### PR TITLE
If pruning fails, try again with the insecure flag

### DIFF
--- a/pruner.sh
+++ b/pruner.sh
@@ -19,6 +19,11 @@ while true; do
   if [ $(date +%H) -eq 3 ]; then
     echo "Pruning old images from registry"
     oc adm prune images --confirm
+    ## If it fails, try to prune from insecure Registry
+    if [ $? -eq 1 ]; then
+      echo "Pruning old images from insecure registry"
+      oc adm prune images --confirm --force-insecure
+    fi
     echo
   fi
 


### PR DESCRIPTION
If Openshift is running with insecure registry, the image pruning will fail:
.....
oc adm prune images --confirm                 
error: error communicating with registry docker-registry.default.svc:5000: [Get https://docker-registry.default.svc:5000/: http: server gave HTTP response to HTTPS client, 
* Append --force-insecure if you really want to prune the registry using insecure connection.]
.....
So try again with "--force-insecure" if pruning fails in first place
