### PR TITLE
Added variable for insecure registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@ The APPUiO pruner prunes old builds, deployments and registry images from an Ope
 
     oc new-project appuio-infra
     oc new-app https://github.com/appuio/appuio-pruner
+
+If you are running an insecure registry, you need to specify the following environment variable:
+
+    oc new-app https://github.com/appuio/appuio-pruner -e INSECURE_REGISTRY=true
+
+Give APPUiO Service Account the required permissions:
+
     oc adm policy add-cluster-role-to-user edit system:serviceaccount:appuio-infra:default
     oc adm policy add-cluster-role-to-user system:image-pruner system:serviceaccount:appuio-infra:default
 

--- a/pruner.sh
+++ b/pruner.sh
@@ -18,7 +18,7 @@ while true; do
   # https://bugzilla.redhat.com/show_bug.cgi?id=1408676
   if [ $(date +%H) -eq 3 ]; then
     # Check if insecure registry variable is set
-    if [ $INSECURE_REGISTRY ]; then
+    if [ "$INSECURE_REGISTRY" = true ]; then
       echo "Pruning old images from insecure registry"
       oc adm prune images --confirm --force-insecure
     else

--- a/pruner.sh
+++ b/pruner.sh
@@ -17,8 +17,14 @@ while true; do
   #
   # https://bugzilla.redhat.com/show_bug.cgi?id=1408676
   if [ $(date +%H) -eq 3 ]; then
-    echo "Pruning old images from registry"
-    oc adm prune images --confirm
+    # Check if insecure registry variable is set
+    if [ $INSECURE_REGISTRY ]; then
+      echo "Pruning old images from insecure registry"
+      oc adm prune images --confirm --force-insecure
+    else
+      echo "Pruning old images from registry"
+      oc adm prune images --confirm
+    fi
     echo
   fi
 


### PR DESCRIPTION
If running an insecure registry, the a APPUiO pruner doesn't prune the images any more
```
sh-4.2$ oc adm prune images --confirm                                                                                                                                                                                                     
error: error communicating with registry docker-registry.default.svc:5000: [Get https://docker-registry.default.svc:5000/: http: server gave HTTP response to HTTPS client,                                                               
* Append --force-insecure if you really want to prune the registry using insecure connection.]  
```
Created a Variable that can be set, if running an insecure registry to let the pruner run as "--force-insecure".
        
