### PR TITLE
Prune images, not deployments in image prune job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.2] - 2018-11-22
+### Fix
+- Actually prune images, not deployments in image pruner job
+
 ## [2.0.1] - 2018-11-20
 ### Changed
 - Allow pruner to clean up deployment pods

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,5 +19,5 @@ appuio_pruner_args:
     - --orphans
     - --confirm
   images:
-    - deployments
+    - images
     - --confirm


### PR DESCRIPTION
The command called by the image prune job was wrong as it called "oc adm
prune deployments", not "oc adm prune images".