### PR TITLE
Use command field to specify command

### DIFF
--- a/files/appuio-pruner-job.yml
+++ b/files/appuio-pruner-job.yml
@@ -53,7 +53,8 @@ objects:
                 - name: pruner
                   image: ${IMAGE}
                   imagePullPolicy: IfNotPresent
-                  args: ${{COMMAND}}
+                  command: ${{COMMAND}}
+                  args: []
                   resources:
                     requests:
                       cpu: 100m


### PR DESCRIPTION
Use the `command` field of the pod spec instead of the `args` field to
configure the command for each job in the job template.

This allows using any image that contains the `oc` binary regardless of
the entrypoint configured for the image.