### PR TITLE
Explicitly set kubeconfig path to /dev/null

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ appuio_pruner_state: present
 
 appuio_pruner_cmd:
   - /usr/bin/oc
+  - --config=/dev/null
   - adm
   - prune
 


### PR DESCRIPTION
Some images which contain `oc` will have a hard-coded path where they
expect a valid kubeconfig file. Because appuio-pruner does not require
any kubeconfig, an easy way to avoid issues where files are not found,
is to explicitly provide the argument `--config=/dev/null` to `oc`.