### PR TITLE
Increase log level

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,7 @@ appuio_pruner_state: present
 appuio_pruner_cmd:
   - /usr/bin/oc
   - --config=/dev/null
+  - --loglevel=1
   - adm
   - prune
 


### PR DESCRIPTION
In case of OOM failures it can be difficult to decipher at what stage
the cron jobs failed. Increasing the log level gives a bit more
information at least.