### PR TITLE
Make prune job resource requests and limits configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,3 +23,8 @@ appuio_pruner_args:
   images:
     - images
     - --confirm
+
+appuio_pruner_cpu_request: 100m
+appuio_pruner_cpu_limit: 250m
+appuio_pruner_memory_request: 128Mi
+appuio_pruner_memory_limit: 2Gi

--- a/files/appuio-pruner-job.yml
+++ b/files/appuio-pruner-job.yml
@@ -24,6 +24,22 @@ parameters:
     name: COMMAND
     required: true
 
+  - description: CPU request
+    name: CPU_REQUEST
+    required: true
+
+  - description: CPU limit
+    name: CPU_LIMIT
+    required: true
+
+  - description: MEMORY request
+    name: MEMORY_REQUEST
+    required: true
+
+  - description: MEMORY limit
+    name: MEMORY_LIMIT
+    required: true
+
 objects:
 
   - apiVersion: batch/v1beta1
@@ -64,10 +80,10 @@ objects:
                   args: []
                   resources:
                     requests:
-                      cpu: 100m
-                      memory: 128Mi
+                      cpu: ${{CPU_REQUEST}}
+                      memory: ${{MEMORY_REQUEST}}
                     limits:
-                      cpu: 250m
-                      memory: 2Gi
+                      cpu: ${{CPU_LIMIT}}
+                      memory: ${{MEMORY_LIMIT}}
               serviceAccountName: pruner
               restartPolicy: Never

--- a/tasks/pruner-present.yml
+++ b/tasks/pruner-present.yml
@@ -44,6 +44,10 @@
           IMAGE: "{{ appuio_pruner_image }}"
           SCHEDULE: "{{ appuio_pruner_schedule }}"
           COMMAND: "{{ cmd | to_json }}"
+          CPU_REQUEST: "{{ appuio_pruner_cpu_request }}"
+          CPU_LIMIT: "{{ appuio_pruner_cpu_limit }}"
+          MEMORY_REQUEST: "{{ appuio_pruner_memory_request }}"
+          MEMORY_LIMIT: "{{ appuio_pruner_memory_limit }}"
 
   always:
     - name: Delete temp directory


### PR DESCRIPTION
Reuse defaults from template:

```
resources:
  requests:
    cpu: 100m
    memory: 128Mi
  limits:
    cpu: 250m
    memory: 2Gi
```

Relates: AMZE-2412